### PR TITLE
Fix syntax warning over comparison of literals using is.

### DIFF
--- a/scripts/gui/generate.py
+++ b/scripts/gui/generate.py
@@ -84,10 +84,10 @@ def generate(command='run', import_from=default_import_from, dry=False, targets=
         log.error('Fatal error: {}'.format(' '.join('"{}"'.format(e.source) for e in errors)))
         sys.exit(1)
 
-    if command is 'run':
+    if command == 'run':
         for to_run in outdated:
             to_run.run(dry)
-    elif command is 'clean':
+    elif command == 'clean':
         for action in actions:
             action.clean(dry)
     else:

--- a/scripts/gui/handler_qrc.py
+++ b/scripts/gui/handler_qrc.py
@@ -75,7 +75,7 @@ class QrcFile(object):
 
     @classmethod
     def fix_import(cls, text):
-        new_string, nb = re.subn(b'\n(qInitResources\(\))', b'\n# \g<1>', text)
+        new_string, nb = re.subn(b'\n(qInitResources\\(\\))', b'\n# \\g<1>', text)
         log.debug('fix_import replaced {} occurrences'.format(nb))
         if nb != 1:
             log.error('fix_import replaced wrong number of occurrences!')

--- a/scripts/gui/handler_ui.py
+++ b/scripts/gui/handler_ui.py
@@ -63,5 +63,5 @@ class UiFile(object):
 
     @classmethod
     def fix_translations(cls, text):
-        new_string, _ = re.subn(b'_translate\(".*?",\s(".*?")\s*?\)', b'_(\g<1>)', text)
+        new_string, _ = re.subn(br'_translate\(".*?",\s(".*?")\s*?\)', br'_(\g<1>)', text)
         return new_string


### PR DESCRIPTION
Fixes #50 . Also fixes below warnings 

```
ind . -iname '*.py' | xargs -P4 -I{} python3.9 -Wall -m py_compile {}  
./scripts/gui/generate.py:87: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if command is 'run':
./scripts/gui/generate.py:90: SyntaxWarning: "is" with a literal. Did you mean "=="?
  elif command is 'clean':
./scripts/gui/handler_qrc.py:78: DeprecationWarning: invalid escape sequence \(
  new_string, nb = re.subn(b'\n(qInitResources\(\))', b'\n# \g<1>', text)
./scripts/gui/handler_qrc.py:78: DeprecationWarning: invalid escape sequence \g
  new_string, nb = re.subn(b'\n(qInitResources\(\))', b'\n# \g<1>', text)
./scripts/gui/handler_ui.py:66: DeprecationWarning: invalid escape sequence \(
  new_string, _ = re.subn(b'_translate\(".*?",\s(".*?")\s*?\)', b'_(\g<1>)', text)
./scripts/gui/handler_ui.py:66: DeprecationWarning: invalid escape sequence \g
  new_string, _ = re.subn(b'_translate\(".*?",\s(".*?")\s*?\)', b'_(\g<1>)', text)
```